### PR TITLE
fix: updated query results to return all rows, and not stop at 1000 i…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,9 +59,21 @@ async function getQueryResults(queryExecutionId) {
   const params = {
     QueryExecutionId: queryExecutionId
   };
+  
+  let result = [];
+  let nextToken = null;
 
-  const command = new GetQueryResultsCommand(params);
-  const result = await client.send(command);
+  do {
+    if (nextToken) {
+      params.NextToken = nextToken;
+    }
+
+    const command = new GetQueryResultsCommand(params);
+    const response = await client.send(command);
+
+    result = result.concat(response.ResultSet.Rows);
+    nextToken = response.NextToken;
+  } while (nextToken);
 
   return result;
 }


### PR DESCRIPTION
closes #1 

Added a fix to get all data from a query using the next Token functionality 