### PR TITLE
Fix: Expose Athena error message (StateChangeReason) from runner

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ async function waitForQueryCompletion(queryExecutionId) {
     if (status === 'SUCCEEDED') {
       break;
     } else if (status === 'FAILED' || status === 'CANCELLED') {
-      throw new Error(`Query execution failed or was cancelled: ${queryExecutionId}`);
+      throw new Error(`Query execution failed or was cancelled: ${queryExecutionId}: ${result.QueryExecution.Status.StateChangeReason}`);
     }
 
     // Sleep for a few seconds before checking again

--- a/src/index.js
+++ b/src/index.js
@@ -195,22 +195,19 @@ export const getRunner = (options) => {
       }
     };
 
-    try {
-      const command = new StartQueryExecutionCommand(params);
-      const response = await client.send(command);
-      const queryExecutionId = response.QueryExecutionId;
+    const command = new StartQueryExecutionCommand(params);
+    const response = await client.send(command);
+    const queryExecutionId = response.QueryExecutionId;
 
-      // Wait for query to complete
-      await waitForQueryCompletion(queryExecutionId);
+    // Wait for query to complete
+    await waitForQueryCompletion(queryExecutionId);
 
-      const queryResults = await getQueryResults(queryExecutionId);
+    const queryResults = await getQueryResults(queryExecutionId);
 
-      // Map the query results to the desired format
-      const output = mapQueryResults(queryResults);
-      return output
-    } catch (error) {
-      console.error('Error executing query:', error);
-    }
+    // Map the query results to the desired format
+    const output = mapQueryResults(queryResults);
+    return output
+
   };
 };
 


### PR DESCRIPTION
Error message in console after fix:

```
  [Processing] higharc_athena
  aws_costs_by_period_product_project ℹ Skipped
/Users/ewebb/code/higharc/analytics/sources/higharc_athena/aws_costs_detailed.sql
  aws_costs_detailed ✖ Error: Query execution failed or was cancelled: 97c9e96a-6dba-47d5-9ce5-5fd3c9aa9458: COLUMN_NOT_FOUND: line 2:5: Column 'billing_period_na' cannot be resolved or requester is not authorized to access requested resources
```

Fixes #55